### PR TITLE
Add mapping from datasets to autonlp tasks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  release:
+    types:
+      - created
+
+jobs:
+  tests:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest
+    - name: Make test
+      run: |
+        make test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest
+        python -m pip install .[dev]
     - name: Make test
       run: |
         make test

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,6 @@ quality:
 style:
 	black --line-length 119 --target-version py38 .
 	isort .
+
+test:
+	pytest -sv ./src/

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ INSTALL_REQUIRES = [
     "tqdm==4.56.0",
     "prettytable==2.0.0",
     "huggingface_hub<0.1.0",
+    "datasets==1.8.0",
 ]
 
 QUALITY_REQUIRE = [
@@ -26,9 +27,11 @@ QUALITY_REQUIRE = [
     "flake8==3.7.9",
 ]
 
+TESTS_REQUIRE = ["pytest"]
+
 
 EXTRAS_REQUIRE = {
-    "dev": INSTALL_REQUIRES + QUALITY_REQUIRE,
+    "dev": INSTALL_REQUIRES + QUALITY_REQUIRE + TESTS_REQUIRE,
     "quality": INSTALL_REQUIRES + QUALITY_REQUIRE,
     "docs": INSTALL_REQUIRES
     + [

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
 INSTALL_REQUIRES = [
     "loguru==0.5.3",
     "requests==2.25.1",
-    "tqdm==4.56.0",
+    "tqdm==4.49",
     "prettytable==2.0.0",
     "huggingface_hub<0.1.0",
     "datasets==1.8.0",

--- a/src/autonlp/autonlp.py
+++ b/src/autonlp/autonlp.py
@@ -10,7 +10,7 @@ import requests
 from loguru import logger
 
 from . import config
-from .evaluate import Evaluate
+from .evaluate import Evaluate, format_task
 from .languages import SUPPORTED_LANGUAGES
 from .metrics import Metrics
 from .project import Project
@@ -103,6 +103,9 @@ class AutoNLP:
 
     def create_evaluation(self, task: str, dataset: str, model: str, col_mapping: str, split: str, config: str = None):
         self._login_from_conf()
+
+        task = format_task(task, dataset, config)
+
         task_id = TASKS.get(task)
         if task_id is None:
             raise ValueError(f"❌ Invalid task selected. Please choose one of {TASKS.keys()}")

--- a/src/autonlp/autonlp.py
+++ b/src/autonlp/autonlp.py
@@ -10,7 +10,7 @@ import requests
 from loguru import logger
 
 from . import config
-from .evaluate import Evaluate, format_task
+from .evaluate import DATASETS_TASKS, Evaluate, format_datasets_task
 from .languages import SUPPORTED_LANGUAGES
 from .metrics import Metrics
 from .project import Project
@@ -104,7 +104,8 @@ class AutoNLP:
     def create_evaluation(self, task: str, dataset: str, model: str, col_mapping: str, split: str, config: str = None):
         self._login_from_conf()
 
-        task = format_task(task, dataset, config)
+        if task in DATASETS_TASKS:
+            task = format_datasets_task(task, dataset, config)
 
         task_id = TASKS.get(task)
         if task_id is None:

--- a/src/autonlp/autonlp.py
+++ b/src/autonlp/autonlp.py
@@ -11,7 +11,7 @@ import requests
 from loguru import logger
 
 from . import config
-from .evaluate import DatasetsTasks, Evaluate, format_datasets_task
+from .evaluate import DATASETS_TASKS, Evaluate, format_datasets_task
 from .languages import SUPPORTED_LANGUAGES
 from .metrics import Metrics
 from .project import Project
@@ -107,7 +107,7 @@ class AutoNLP:
     ):
         self._login_from_conf()
 
-        if task in DatasetsTasks.__members__:
+        if task in DATASETS_TASKS:
             task = format_datasets_task(task, dataset, config)
             if col_mapping:
                 warning.warn("A task template from `datasets` has been selected. Deleting `col_mapping` ...")

--- a/src/autonlp/autonlp.py
+++ b/src/autonlp/autonlp.py
@@ -121,11 +121,12 @@ class AutoNLP:
         if task_id is None:
             raise ValueError(f"❌ Invalid task selected. Please choose one of {TASKS.keys()}")
 
-        col_mapping = col_mapping.strip().split(",")
-        mapping_dict = {}
-        for c_m in col_mapping:
-            k, v = c_m.split(":")
-            mapping_dict[k] = v
+        if col_mapping:
+            col_mapping = col_mapping.strip().split(",")
+            mapping_dict = {}
+            for c_m in col_mapping:
+                k, v = c_m.split(":")
+                mapping_dict[k] = v
 
         payload = {
             "username": self.username,

--- a/src/autonlp/autonlp.py
+++ b/src/autonlp/autonlp.py
@@ -10,7 +10,7 @@ import requests
 from loguru import logger
 
 from . import config
-from .evaluate import Evaluate, format_datasets_task
+from .evaluate import Evaluate, format_datasets_task, get_dataset_splits
 from .languages import SUPPORTED_LANGUAGES
 from .metrics import Metrics
 from .project import Project
@@ -105,6 +105,10 @@ class AutoNLP:
         self, task: str, dataset: str, model: str, split: str, col_mapping: str = None, config: str = None
     ):
         self._login_from_conf()
+
+        splits = get_dataset_splits(dataset=dataset, config=config)
+        if split not in splits:
+            raise ValueError(f"❌ Split {split} not found in dataset {dataset}. Available splits: {splits}")
 
         if task in DATASETS_TASKS:
             task = format_datasets_task(task, dataset, config)

--- a/src/autonlp/autonlp.py
+++ b/src/autonlp/autonlp.py
@@ -110,7 +110,7 @@ class AutoNLP:
         if task in DatasetsTasks.__members__:
             task = format_datasets_task(task, dataset, config)
             if col_mapping:
-                warning.warn(f"A task template from `datasets` has been selected. Deleting `col_mapping` ...")
+                warning.warn("A task template from `datasets` has been selected. Deleting `col_mapping` ...")
                 col_mapping = None
         elif col_mapping is None:
             raise ValueError(

--- a/src/autonlp/autonlp.py
+++ b/src/autonlp/autonlp.py
@@ -4,13 +4,14 @@ Copyright 2020 The HuggingFace Team
 
 import json
 import os
+from logging import warning
 from typing import Optional
 
 import requests
 from loguru import logger
 
 from . import config
-from .evaluate import DATASETS_TASKS, Evaluate, format_datasets_task
+from .evaluate import DatasetsTasks, Evaluate, format_datasets_task
 from .languages import SUPPORTED_LANGUAGES
 from .metrics import Metrics
 from .project import Project
@@ -101,11 +102,20 @@ class AutoNLP:
         self._project.refresh()
         return self._project
 
-    def create_evaluation(self, task: str, dataset: str, model: str, col_mapping: str, split: str, config: str = None):
+    def create_evaluation(
+        self, task: str, dataset: str, model: str, split: str, col_mapping: str = None, config: str = None
+    ):
         self._login_from_conf()
 
-        if task in DATASETS_TASKS:
+        if task in DatasetsTasks.__members__:
             task = format_datasets_task(task, dataset, config)
+            if col_mapping:
+                warning.warn(f"A task template from `datasets` has been selected. Deleting `col_mapping` ...")
+                col_mapping = None
+        elif col_mapping is None:
+            raise ValueError(
+                f"❌ A column mapping must be provided for task {TASKS.keys()}. Please provide a value for `col_mapping`."
+            )
 
         task_id = TASKS.get(task)
         if task_id is None:

--- a/src/autonlp/autonlp.py
+++ b/src/autonlp/autonlp.py
@@ -4,7 +4,6 @@ Copyright 2020 The HuggingFace Team
 
 import json
 import os
-from logging import warning
 from typing import Optional
 
 import requests
@@ -110,7 +109,7 @@ class AutoNLP:
         if task in DATASETS_TASKS:
             task = format_datasets_task(task, dataset, config)
             if col_mapping:
-                warning.warn("A task template from `datasets` has been selected. Deleting `col_mapping` ...")
+                logger.warning("A task template from `datasets` has been selected. Deleting `col_mapping` ...")
                 col_mapping = None
         elif col_mapping is None:
             raise ValueError(

--- a/src/autonlp/autonlp.py
+++ b/src/autonlp/autonlp.py
@@ -114,7 +114,7 @@ class AutoNLP:
                 col_mapping = None
         elif col_mapping is None:
             raise ValueError(
-                f"❌ A column mapping must be provided for task {TASKS.keys()}. Please provide a value for `col_mapping`."
+                f"❌ A column mapping must be provided for task {task}. Please provide a value for `col_mapping`."
             )
 
         task_id = TASKS.get(task)

--- a/src/autonlp/autonlp.py
+++ b/src/autonlp/autonlp.py
@@ -10,11 +10,11 @@ import requests
 from loguru import logger
 
 from . import config
-from .evaluate import DATASETS_TASKS, Evaluate, format_datasets_task
+from .evaluate import Evaluate, format_datasets_task
 from .languages import SUPPORTED_LANGUAGES
 from .metrics import Metrics
 from .project import Project
-from .tasks import TASKS
+from .tasks import DATASETS_TASKS, TASKS
 from .utils import UnauthenticatedError, http_get, http_post
 
 
@@ -120,9 +120,9 @@ class AutoNLP:
         if task_id is None:
             raise ValueError(f"❌ Invalid task selected. Please choose one of {TASKS.keys()}")
 
+        mapping_dict = {}
         if col_mapping:
             col_mapping = col_mapping.strip().split(",")
-            mapping_dict = {}
             for c_m in col_mapping:
                 k, v = c_m.split(":")
                 mapping_dict[k] = v

--- a/src/autonlp/cli/evaluate.py
+++ b/src/autonlp/cli/evaluate.py
@@ -81,8 +81,8 @@ class CreateEvaluationCommand(BaseAutoNLPCommand):
             task=self._task,
             dataset=self._dataset,
             model=self._model,
-            col_mapping=self._col_mapping,
             split=self._split,
+            col_mapping=self._col_mapping,
             config=self._config,
         )
         print(eval_project)

--- a/src/autonlp/cli/evaluate.py
+++ b/src/autonlp/cli/evaluate.py
@@ -8,6 +8,9 @@ from .common import COL_MAPPING_HELP
 
 
 def create_evaluation_command_factory(args):
+    if args.task not in DATASETS_TASKS:
+        if args.col_mapping is None:
+            raise Exception("`col_mapping` is required if task is not a datasets task")
     return CreateEvaluationCommand(args.task, args.dataset, args.model, args.col_mapping, args.split, args.config)
 
 
@@ -22,7 +25,7 @@ class CreateEvaluationCommand(BaseAutoNLPCommand):
             default=None,
             required=True,
             help=f"The evaluation task type, one of: {list(TASKS.keys())}",
-            choices=list(TASKS.keys()) + list(DATASETS_TASKS.keys()),
+            choices=list(TASKS.keys()) + DATASETS_TASKS,
         )
         create_evaluation_parser.add_argument(
             "--dataset",
@@ -44,7 +47,7 @@ class CreateEvaluationCommand(BaseAutoNLPCommand):
             "--col_mapping",
             type=str,
             default=None,
-            required=True,
+            required=False,
             help=COL_MAPPING_HELP,
         )
         create_evaluation_parser.add_argument(

--- a/src/autonlp/cli/evaluate.py
+++ b/src/autonlp/cli/evaluate.py
@@ -2,7 +2,7 @@ from argparse import ArgumentParser
 
 from loguru import logger
 
-from ..tasks import TASKS
+from ..tasks import DATASETS_TASKS, TASKS
 from . import BaseAutoNLPCommand
 from .common import COL_MAPPING_HELP
 
@@ -22,7 +22,7 @@ class CreateEvaluationCommand(BaseAutoNLPCommand):
             default=None,
             required=True,
             help=f"The evaluation task type, one of: {list(TASKS.keys())}",
-            choices=list(TASKS.keys()),
+            choices=list(TASKS.keys()) + list(DATASETS_TASKS.keys()),
         )
         create_evaluation_parser.add_argument(
             "--dataset",

--- a/src/autonlp/evaluate.py
+++ b/src/autonlp/evaluate.py
@@ -47,9 +47,6 @@ class Evaluate:
         return output
 
 
-DATASETS_TASKS = ["text-classification", "question-answering-extractive"]
-
-
 def format_datasets_task(task: str, dataset: str, config: str = None):
     task_template = get_compatible_task_template(task, dataset, config)
     if task_template:

--- a/src/autonlp/evaluate.py
+++ b/src/autonlp/evaluate.py
@@ -52,7 +52,7 @@ AUTONLP_TO_DATASETS_TASKS = {
     "text_classification": "text-classification",
     "extractive_question_answering": "question-answering-extractive",
 }
-DATASETS_TO_AUTONLP_TASKS = {v: k for k, v in DATASETS_TASKS.items()}
+DATASETS_TO_AUTONLP_TASKS = {v: k for k, v in AUTONLP_TO_DATASETS_TASKS.items()}
 
 
 def format_datasets_task(task: str, dataset: str, config: str = None):

--- a/src/autonlp/evaluate.py
+++ b/src/autonlp/evaluate.py
@@ -86,3 +86,11 @@ def get_compatible_task_template(task: str, dataset: str, config: str = None):
         return compatible_templates[0]
     else:
         return None
+
+
+def get_dataset_splits(dataset: str, config: str = None):
+    module, module_hash = prepare_module(dataset)
+    builder_cls = import_main_class(module)
+    builder = builder_cls(hash=module_hash, name=config)
+    splits = builder.info.splits.keys()
+    return list(splits)

--- a/src/autonlp/evaluate.py
+++ b/src/autonlp/evaluate.py
@@ -1,3 +1,4 @@
+import enum
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -47,12 +48,14 @@ class Evaluate:
         return output
 
 
-DATASETS_TASKS = ["text_classification"]
+class DatasetsTasks(enum.IntEnum):
+    text_classification = 1
+
+
 AUTONLP_TO_DATASETS_TASKS = {
     "text_classification": "text-classification",
     "extractive_question_answering": "question-answering-extractive",
 }
-DATASETS_TO_AUTONLP_TASKS = {v: k for k, v in AUTONLP_TO_DATASETS_TASKS.items()}
 
 
 def format_datasets_task(task: str, dataset: str, config: str = None):
@@ -84,9 +87,7 @@ def get_compatible_task_template(task: str, dataset: str, config: str = None):
             template for template in templates if template.task == AUTONLP_TO_DATASETS_TASKS.get(task)
         ]
         if not compatible_templates:
-            raise ValueError(
-                f"❌ Task `{task}` is not compatible with dataset `{dataset}`! Available tasks: {[DATASETS_TO_AUTONLP_TASKS.get(t.task) for t in templates]}"
-            )
+            raise ValueError(f"❌ Task `{task}` is not compatible with dataset `{dataset}`!")
         if len(compatible_templates) > 1:
             raise ValueError(
                 f"❌ Expected 1 task template but found {len(compatible_templates)}! Please ensure that `datasets.DatasetInfo.task_templates` contains a unique set of task types."

--- a/src/autonlp/evaluate.py
+++ b/src/autonlp/evaluate.py
@@ -1,4 +1,3 @@
-import enum
 from dataclasses import dataclass
 from datetime import datetime
 

--- a/src/autonlp/evaluate.py
+++ b/src/autonlp/evaluate.py
@@ -57,6 +57,8 @@ def format_datasets_task(task: str, dataset: str, config: str = None):
             # TODO(lewtun): add logic for multilabel classification when implemented in `datasets`
             elif num_labels > 2:
                 task = "multi_class_classification"
+            else:
+                raise Exception("Invalid `num_labels`")
         elif task == "question-answering-extractive":
             task = "extractive_question_answering"
         else:

--- a/src/autonlp/evaluate.py
+++ b/src/autonlp/evaluate.py
@@ -47,31 +47,50 @@ class Evaluate:
         return output
 
 
-def format_task(task: str, dataset: str, config: str = None):
-    task_templates = get_task_templates(dataset, config)
-    if task == "text_classification":
-        compatible_templates = [template for template in task_templates if template.task == "text-classification"]
-        if not compatible_templates:
-            raise ValueError(f"Task {task} is not compatible with this dataset! Available tasks: {task_templates}")
-        if len(compatible_templates) > 1:
-            raise ValueError(
-                f"Expected 1 task template but found {len(compatible_templates)}! Please ensure that `datasets.DatasetInfo.task_templates` contains a unique set of task types."
-            )
-        task_template = compatible_templates[0]
-        num_labels = len(task_template.labels)
-        if num_labels == 2:
-            task = "binary_classification"
-        elif num_labels > 2:
-            task = "multi_class_classification"
-        else:
-            raise ValueError(
-                f"Dataset `{dataset}` with configuration `{config}` is not suitable for text_classification!"
-            )
+DATASETS_TASKS = ["text_classification"]
+AUTONLP_TO_DATASETS_TASKS = {
+    "text_classification": "text-classification",
+    "extractive_question_answering": "question-answering-extractive",
+}
+DATASETS_TO_AUTONLP_TASKS = {v: k for k, v in DATASETS_TASKS.items()}
+
+
+def format_datasets_task(task: str, dataset: str, config: str = None):
+    task_template = get_compatible_task_template(task, dataset, config)
+    if task_template:
+        if task == "text_classification":
+            num_labels = len(task_template.labels)
+            if num_labels == 2:
+                task = "binary_classification"
+            # TODO(lewtun): add logic for multilabel classification when implemented in `datasets`
+            elif num_labels > 2:
+                task = "multi_class_classification"
+            else:
+                raise ValueError(f"❌ Dataset `{dataset}` with configuration `{config}` is not suitable for `{task}`!")
+    else:
+        raise ValueError(
+            f"❌ Dataset `{dataset}` with configuration `{config}` does not have a task template for `{task}`! Please select a different task and/or dataset."
+        )
     return task
 
 
-def get_task_templates(dataset: str, config: str = None):
+def get_compatible_task_template(task: str, dataset: str, config: str = None):
     module, module_hash = prepare_module(dataset)
     builder_cls = import_main_class(module)
     builder = builder_cls(hash=module_hash, name=config)
-    return builder.info.task_templates
+    templates = builder.info.task_templates
+    if templates:
+        compatible_templates = [
+            template for template in templates if template.task == AUTONLP_TO_DATASETS_TASKS.get(task)
+        ]
+        if not compatible_templates:
+            raise ValueError(
+                f"❌ Task `{task}` is not compatible with dataset `{dataset}`! Available tasks: {[DATASETS_TO_AUTONLP_TASKS.get(t.task) for t in templates]}"
+            )
+        if len(compatible_templates) > 1:
+            raise ValueError(
+                f"❌ Expected 1 task template but found {len(compatible_templates)}! Please ensure that `datasets.DatasetInfo.task_templates` contains a unique set of task types."
+            )
+        return compatible_templates[0]
+    else:
+        return None

--- a/src/autonlp/tasks.py
+++ b/src/autonlp/tasks.py
@@ -6,3 +6,5 @@ TASKS = {
     "single_column_regression": 10,
     "speech_recognition": 11,
 }
+
+DATASETS_TASKS = ["text-classification", "question-answering-extractive"]

--- a/src/autonlp/tests/test_task_formatting.py
+++ b/src/autonlp/tests/test_task_formatting.py
@@ -1,0 +1,43 @@
+import unittest
+
+from datasets import tasks
+
+from autonlp.evaluate import format_datasets_task, get_compatible_task_template
+
+
+class TestFormatDatasetsTask(unittest.TestCase):
+    def test_binary_classification(self):
+        autonlp_task = "binary_classification"
+        formatted_task = format_datasets_task("text_classification", "allocine")
+        self.assertEqual(autonlp_task, formatted_task)
+
+    def test_multi_class_classification(self):
+        autonlp_task = "multi_class_classification"
+        formatted_task = format_datasets_task("text_classification", "ag_news")
+        self.assertEqual(autonlp_task, formatted_task)
+
+    def test_dataset_without_template(self):
+        # TODO(lewtun): Replace with dedicated dummy dataset on Hugging Face Hub
+        self.assertRaises(
+            ValueError,
+            format_datasets_task,
+            "text_classification",
+            "patrickvonplaten/scientific_papers_dummy",
+            "pubmed",
+        )
+
+
+class TestGetCompatibleTaskTemplate(unittest.TestCase):
+    def test_text_classification(self):
+        task_template = get_compatible_task_template("text_classification", "allocine")
+        self.assertIsInstance(task_template, tasks.TextClassification)
+
+    def test_dataset_without_template(self):
+        # TODO(lewtun): Replace with dedicated dummy dataset on Hugging Face Hub
+        task_template = get_compatible_task_template(
+            "text_classification", "patrickvonplaten/scientific_papers_dummy", "pubmed"
+        )
+        self.assertIsNone(task_template)
+
+    def test_incompatible_task(self):
+        self.assertRaises(ValueError, get_compatible_task_template, "text_classification", "squad")

--- a/src/autonlp/tests/test_task_formatting.py
+++ b/src/autonlp/tests/test_task_formatting.py
@@ -8,12 +8,12 @@ from autonlp.evaluate import format_datasets_task, get_compatible_task_template
 class TestFormatDatasetsTask(unittest.TestCase):
     def test_binary_classification(self):
         autonlp_task = "binary_classification"
-        formatted_task = format_datasets_task("text_classification", "allocine")
+        formatted_task = format_datasets_task("text-classification", "allocine")
         self.assertEqual(autonlp_task, formatted_task)
 
     def test_multi_class_classification(self):
         autonlp_task = "multi_class_classification"
-        formatted_task = format_datasets_task("text_classification", "ag_news")
+        formatted_task = format_datasets_task("text-classification", "ag_news")
         self.assertEqual(autonlp_task, formatted_task)
 
     def test_dataset_without_template(self):
@@ -29,7 +29,7 @@ class TestFormatDatasetsTask(unittest.TestCase):
 
 class TestGetCompatibleTaskTemplate(unittest.TestCase):
     def test_text_classification(self):
-        task_template = get_compatible_task_template("text_classification", "allocine")
+        task_template = get_compatible_task_template("text-classification", "allocine")
         self.assertIsInstance(task_template, tasks.TextClassification)
 
     def test_dataset_without_template(self):
@@ -40,4 +40,4 @@ class TestGetCompatibleTaskTemplate(unittest.TestCase):
         self.assertIsNone(task_template)
 
     def test_incompatible_task(self):
-        self.assertRaises(ValueError, get_compatible_task_template, "text_classification", "squad")
+        self.assertRaises(ValueError, get_compatible_task_template, "text-classification", "squad")


### PR DESCRIPTION
This PR adds a step in the evaluation to convert between the different task APIs in `autonlp` and `datasets`. 

The main idea is to allow users to provide a new `text-classification` task in the CLI that gets mapped this to one of `binary_classification`, `multi_class_classification`, or (eventually) `multi_label_classification`:

```python
from autonlp.evaluate import format_datasets_task

# returns "binary_classification"
format_datasets_task(task="text-classification", dataset="allocine")
# returns "multi_class_classification"
format_datasets_task(task="text-classification", dataset="ag_news")
```