### PR TITLE
Refactor the authentication process

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,13 +1,68 @@
-Installation
+First steps with AutoNLP
 ===================================
 
-Installing AutoNLP is super-easy! Since we are moving quite fast with the development of this library, it's always wise to use the latest version from pypi.
+Introduction
+...................................
 
-To install, you can use `pip`:
+You can use AutoNLP in three ways:
+
+#. With the AutoNLP `web interface <https://ui.autonlp.huggingface.co>`_
+#. With the AutoNLP CLI tool
+#. With the AutoNLP Python package
+
+The AutoNLP UI is the recommended way to use AutoNLP if you're not familiar with Python or the terminal.
+The CLI / Python package supports some additional tasks, and allows you to use AutoNLP programatically.
+
+Installation instructions
+...................................
+
+Installing the AutoNLP Python package is super-easy! Since we are moving quite fast with the development of this library, it's always wise to use the latest version from pypi.
+
+To install, you can use ``pip``:
 
 .. code-block:: bash
 
     $ pip install -U autonlp
 
 
-Please make sure that you have git lfs installed. Check out the instructions here: https://github.com/git-lfs/git-lfs/wiki/Installation
+Please make sure that you have ``git-lfs`` installed. Check out the instructions here: https://github.com/git-lfs/git-lfs/wiki/Installation
+
+First steps with the CLI
+..................................
+
+Logging in
+----------------------------------
+
+To log in AutoNLP, use your HuggingFace API token:
+
+.. code-block:: bash
+
+    autonlp login --api-key YOUR_HUGGING_FACE_API_TOKEN
+
+Your API token can be found under in the settings section of your HuggingFace profile, on the `HuggingFace website <https://huggingface.co/settings/profile>`_
+
+Using AutoNLP as an organization
+----------------------------------
+
+By default, AutoNLP creates and retrieves projects as you.
+But you can create an AutoNLP project as an organization, if you are a member of this organization.
+This will allow all the organization members to see and interact with the project.
+
+To create an AutoNLP project as an organization, simply append: ``--username ORGANIZATION_NAME`` to the AutoNLP command.
+For example, to retrieve a project's info that belongs to the organization ``my_org``, run:
+
+.. code-block:: bash
+
+    autonlp project_info --name my_project --username my_org
+
+You can change the default identity AutoNLP uses to manage projects by running ``autonlp select_identity``:
+
+.. code-block:: bash
+
+    autonlp select_identity my_org
+
+To print the current default identity and the ones available to you, run:
+
+.. code-block:: bash
+
+    autonlp list_identities

--- a/docs/training_hub_model.rst
+++ b/docs/training_hub_model.rst
@@ -1,5 +1,5 @@
 Training A Model From Hugging Face Hub
-===================================
+==============================================
 
 Using AutoNLP you can also finetune a model that is hosted on Hugging Face Hub. You can choose from one of the
 10K+ models hosted here: http://hf.co/models. The model must have it's own tokenizer!

--- a/src/autonlp/auth.py
+++ b/src/autonlp/auth.py
@@ -1,0 +1,126 @@
+import json
+import os
+from dataclasses import dataclass
+from json.decoder import JSONDecodeError
+from typing import List, Optional
+
+import requests
+from loguru import logger
+from typing_extensions import TypedDict
+
+from . import config
+from .utils import http_get
+
+
+class NotAuthenticatedError(ValueError):
+    """The user is not authenticated"""
+
+    pass
+
+
+class AuthenticationError(ValueError):
+    """An error occurred while authenticated"""
+
+    pass
+
+
+class ForbiddenError(ValueError):
+    """The user is authenticated but has not the appropriate rights"""
+
+    pass
+
+
+@dataclass
+class AutoNLPIdentity:
+    name: str
+    full_name: str
+    is_org: bool
+
+
+LoginInfo = TypedDict("LoginInfo", {"token": str, "identities": List[AutoNLPIdentity], "selected_identity": str})
+
+
+def login(token: str, save_dir: Optional[str] = None) -> LoginInfo:
+    if token.startswith("api_org"):
+        raise AuthenticationError("Cannot login with an organization token! Please login as a user.")
+
+    try:
+        auth_resp = http_get(path="/whoami-v2", domain=config.HF_API, token=token, token_prefix="Bearer")
+    except requests.HTTPError as err:
+        if err.response.status_code == 401:
+            raise AuthenticationError("The provided token is invalid") from err
+        raise err
+
+    json_resp = auth_resp.json()
+
+    identities = [
+        AutoNLPIdentity(
+            name=identity["name"],
+            full_name=identity["fullname"],
+            is_org=identity["type"] == "org",
+        )
+        for identity in [json_resp] + json_resp.get("orgs", [])
+    ]
+
+    try:
+        login_info = _save_identities(identities=identities, token=token, save_dir=save_dir)
+    except ValueError as err:
+        raise AuthenticationError(*err.args) from err
+
+    return login_info
+
+
+def _save_identities(
+    identities: List[AutoNLPIdentity],
+    token: str,
+    selected_identity: Optional[str] = None,
+    save_dir: Optional[str] = None,
+) -> LoginInfo:
+    if save_dir is None:
+        save_dir = "~/.autonlp"
+    save_dir = os.path.expanduser(save_dir)
+
+    logger.info(f"🗝 Storing credentials in: {save_dir}")
+    if os.path.isfile(save_dir):
+        raise ValueError(f"'{save_dir}' is a file, cannot save credentials there")
+    if not os.path.exists(save_dir):
+        os.makedirs(save_dir)
+
+    if selected_identity is None:
+        selected_identity = identities[0].name
+
+    login_dict = LoginInfo(token=token, identities=identities, selected_identity=selected_identity)
+    save_path = os.path.join(save_dir, "autonlp.json")
+    with open(save_path, "w") as fp:
+        json.dump(login_dict, fp)
+
+    return login_dict
+
+
+def login_from_conf(save_dir: Optional[str] = None) -> LoginInfo:
+    if save_dir is None:
+        save_dir = "~/.autonlp"
+    save_dir = os.path.expanduser(save_dir)
+    save_path = os.path.join(save_dir, "autonlp.json")
+    if not os.path.isfile(save_path):
+        raise NotAuthenticatedError(f"{save_path} not found")
+
+    logger.info(f"🗝 Retrieving credentials from '{save_dir}'")
+    with open(save_path, "r") as fp:
+        try:
+            login_dict = json.load(fp)
+        except JSONDecodeError as err:
+            raise AuthenticationError(f"{save_path} is malformed") from err
+
+    return login_dict
+
+
+def select_identity(new_identity: str, save_dir: Optional[str] = None):
+    login_info = login_from_conf(save_dir)
+    if new_identity not in [identity.name for identity in login_info["identities"]]:
+        raise ForbiddenError(f"Cannot impersonate {new_identity}: if it's an org, make sure you're a member of it")
+    new_login_info = {
+        **login_info,
+        "selected_identity": new_identity,
+    }
+    _save_identities(**new_login_info, save_dir=save_dir)

--- a/src/autonlp/auth.py
+++ b/src/autonlp/auth.py
@@ -1,6 +1,5 @@
 import json
 import os
-from dataclasses import dataclass
 from json.decoder import JSONDecodeError
 from typing import List, Optional
 
@@ -30,13 +29,7 @@ class ForbiddenError(ValueError):
     pass
 
 
-@dataclass
-class AutoNLPIdentity:
-    name: str
-    full_name: str
-    is_org: bool
-
-
+AutoNLPIdentity = TypedDict("AutoNLPIdentity", {"name": str, "full_name": str, "is_org": bool})
 LoginInfo = TypedDict("LoginInfo", {"token": str, "identities": List[AutoNLPIdentity], "selected_identity": str})
 
 
@@ -87,10 +80,10 @@ def _save_identities(
         os.makedirs(save_dir)
 
     if selected_identity is None:
-        selected_identity = identities[0].name
+        selected_identity = identities[0]["name"]
 
     login_dict = LoginInfo(token=token, identities=identities, selected_identity=selected_identity)
-    save_path = os.path.join(save_dir, "autonlp.json")
+    save_path = os.path.join(save_dir, "auth.json")
     with open(save_path, "w") as fp:
         json.dump(login_dict, fp)
 
@@ -101,7 +94,7 @@ def login_from_conf(save_dir: Optional[str] = None) -> LoginInfo:
     if save_dir is None:
         save_dir = "~/.autonlp"
     save_dir = os.path.expanduser(save_dir)
-    save_path = os.path.join(save_dir, "autonlp.json")
+    save_path = os.path.join(save_dir, "auth.json")
     if not os.path.isfile(save_path):
         raise NotAuthenticatedError(f"{save_path} not found")
 
@@ -117,7 +110,7 @@ def login_from_conf(save_dir: Optional[str] = None) -> LoginInfo:
 
 def select_identity(new_identity: str, save_dir: Optional[str] = None):
     login_info = login_from_conf(save_dir)
-    if new_identity not in [identity.name for identity in login_info["identities"]]:
+    if new_identity not in [identity["name"] for identity in login_info["identities"]]:
         raise ForbiddenError(f"Cannot impersonate {new_identity}: if it's an org, make sure you're a member of it")
     new_login_info = {
         **login_info,

--- a/src/autonlp/autonlp.py
+++ b/src/autonlp/autonlp.py
@@ -68,7 +68,7 @@ class AutoNLP:
         if username is None:
             username = login_info["selected_identity"]
             logger.warning(f"Creating project under identity: '{username}'")
-        if username not in [identity.name for identity in login_info["identities"]]:
+        if username not in [identity["name"] for identity in login_info["identities"]]:
             raise ForbiddenError(f"Cannot impersonate '{username}'")
 
         task_id = TASKS.get(task)
@@ -114,7 +114,7 @@ class AutoNLP:
         if username is None:
             username = login_info["selected_identity"]
             logger.warning(f"Creating evaluation project under identity: '{username}'")
-        if username not in [identity.name for identity in login_info["identities"]]:
+        if username not in [identity["name"] for identity in login_info["identities"]]:
             raise ForbiddenError(f"Cannot impersonate '{username}'")
 
         splits = get_dataset_splits(dataset=dataset, config=config)
@@ -165,7 +165,7 @@ class AutoNLP:
         if username is None:
             username = login_info["selected_identity"]
             logger.warning(f"Creating benhchmark project under identity: '{username}'")
-        if username not in [identity.name for identity in login_info["identities"]]:
+        if username not in [identity["name"] for identity in login_info["identities"]]:
             raise ForbiddenError(f"Cannot impersonate '{username}'")
 
         task_id = 1
@@ -193,7 +193,7 @@ class AutoNLP:
         if username is None:
             username = login_info["selected_identity"]
             logger.warning(f"Creating benhchmark project under identity: '{username}'")
-        if username not in [identity.name for identity in login_info["identities"]]:
+        if username not in [identity["name"] for identity in login_info["identities"]]:
             raise ForbiddenError(f"Cannot impersonate '{username}'")
 
         if is_eval:
@@ -229,7 +229,7 @@ class AutoNLP:
         if username is None:
             username = login_info["selected_identity"]
             logger.warning(f"Creating benhchmark project under identity: '{username}'")
-        if username not in [identity.name for identity in login_info["identities"]]:
+        if username not in [identity["name"] for identity in login_info["identities"]]:
             raise ForbiddenError(f"Cannot impersonate '{username}'")
 
         try:
@@ -248,7 +248,7 @@ class AutoNLP:
         if username is None:
             username = login_info["selected_identity"]
             logger.warning(f"Creating benhchmark project under identity: '{username}'")
-        if username not in [identity.name for identity in login_info["identities"]]:
+        if username not in [identity["name"] for identity in login_info["identities"]]:
             raise ForbiddenError(f"Cannot impersonate '{username}'")
 
         try:
@@ -268,7 +268,7 @@ class AutoNLP:
         login_info = login_from_conf()
         if username is None:
             username = login_info["selected_identity"]
-        if username not in [identity.name for identity in login_info["identities"]]:
+        if username not in [identity["name"] for identity in login_info["identities"]]:
             raise ForbiddenError(f"Cannot impersonate '{username}'")
 
         logger.info(f"📄 Retrieving projects of user {username}...")
@@ -279,7 +279,7 @@ class AutoNLP:
         login_info = login_from_conf()
         if username is None:
             username = login_info["selected_identity"]
-        if username not in [identity.name for identity in login_info["identities"]]:
+        if username not in [identity["name"] for identity in login_info["identities"]]:
             raise ForbiddenError(f"Cannot impersonate '{username}'")
         project = self.get_project(name=proj_name)
         return project.estimate_cost(num_train_samples)

--- a/src/autonlp/autonlp.py
+++ b/src/autonlp/autonlp.py
@@ -4,24 +4,22 @@ Copyright 2020 The HuggingFace Team
 
 import json
 import os
-from typing import Optional
+from typing import List, Optional
 
 import requests
 from loguru import logger
 
-from . import config
+from .auth import ForbiddenError, login, login_from_conf, select_identity
 from .evaluate import Evaluate, format_datasets_task, format_eval_status, get_dataset_splits
 from .languages import SUPPORTED_LANGUAGES
 from .metrics import Metrics
 from .project import Project
 from .tasks import DATASETS_TASKS, TASKS
-from .utils import UnauthenticatedError, http_get, http_post
+from .utils import http_get, http_post
 
 
 class AutoNLP:
     def __init__(self, config_dir: str = None) -> None:
-        self.username = None
-        self.token = None
         self._project = None
         self._eval_proj = None
         self.config_dir = config_dir
@@ -30,62 +28,59 @@ class AutoNLP:
             self.config_dir = os.path.join(home_dir, ".autonlp")
         os.makedirs(self.config_dir, exist_ok=True)
 
-    def get_token(self):
-        """Retrieve API token, or raise UnauthenticatedError"""
-        self._login_from_conf()
-        if self.token is None:
-            raise UnauthenticatedError("❌ Credentials not found ! Please login to AutoNLP first.")
-        return self.token
+    def get_token(self) -> str:
+        """Retrieve API token
+
+        Raises:
+            :class:``.auth.NotAuthenticatedError``:
+                Not authenticated (you need to login first)
+            :class:``.auth.AuthenticationError``:
+                Failed to authenticate
+        """
+        login_info = login_from_conf(save_dir=self.config_dir)
+        return login_info["token"]
 
     def login(self, token: str):
-        """Login to AutoNLP"""
-        try:
-            auth_resp = http_get(path="/whoami-v2", domain=config.HF_API, token=token, token_prefix="Bearer")
-        except requests.HTTPError as err:
-            if err.response.status_code == 401:
-                logger.error("❌ Failed to authenticate. Check the passed token is valid!")
-            raise
-        user_identity = auth_resp.json()
-        self.username = user_identity["name"]
-        logger.info(f"🗝 Successfully logged in as {self.username}")
-        orgs = []
-        if user_identity["type"] == "user":
-            orgs = [org["name"] for org in user_identity["orgs"]]
-        self.orgs = orgs
-        self.token = token
-        login_dict = {"username": self.username, "orgs": self.orgs, "token": token}
-        logger.info(f"🗝 Storing credentials in:  {self.config_dir}")
-        with open(os.path.join(self.config_dir, "autonlp.json"), "w") as fp:
-            json.dump(login_dict, fp)
+        """Login to AutoNLP
 
-    def _login_from_conf(self):
-        """Retrieve credentials from local config"""
-        conf_json = None
-        if self.username is None or self.token is None:
-            logger.info("🗝 Retrieving credentials from config...")
-            if os.path.isfile(os.path.join(self.config_dir, "autonlp.json")):
-                with open(os.path.join(self.config_dir, "autonlp.json"), "r") as conf_file:
-                    conf_json = json.load(conf_file)
-                    if conf_json is None:
-                        raise UnauthenticatedError("❌ Credentials not found! Please login to AutoNLP first.")
-                    else:
-                        self.username = conf_json["username"]
-                        self.orgs = conf_json["orgs"]
-                        self.token = conf_json["token"]
+        Raises:
+            :class:``.auth.AuthenticationError``:
+                Failed to authenticate
+            :class:``requests.HTTPError``:
+                Failed to reach AutoNLP's API
+        """
+        login(token, save_dir=self.config_dir)
 
-    def create_project(self, name: str, task: str, language: str, max_models: int, hub_model: str = None):
+    def switch_identity(self, new_identity: str):
+        select_identity(new_identity=new_identity, save_dir=self.config_dir)
+
+    def create_project(
+        self,
+        name: str,
+        task: str,
+        language: str,
+        max_models: int,
+        hub_model: Optional[str] = None,
+        username: Optional[str] = None,
+    ) -> Project:
         """Create a project and return it"""
-        self._login_from_conf()
+        login_info = login_from_conf(save_dir=self.config_dir)
+        if username is None:
+            username = login_info["selected_identity"]
+            logger.warning(f"Creating project under identity: '{username}'")
+        if username not in [identity.name for identity in login_info["identities"]]:
+            raise ForbiddenError(f"Cannot impersonate '{username}'")
+
         task_id = TASKS.get(task)
         if task_id is None:
             raise ValueError(f"❌ Invalid task selected. Please choose one of {TASKS.keys()}")
+
         language = str(language).strip().lower()
         if language not in SUPPORTED_LANGUAGES:
             raise ValueError("❌ Invalid language selected. Please check supported languages in AutoNLP documentation.")
-        if task_id is None:
-            raise ValueError(f"❌ Invalid task specified. Please choose one of {list(TASKS.keys())}")
+
         payload = {
-            "username": self.username,
+            "username": username,
             "proj_name": name,
             "task": task_id,
             "config": {
@@ -94,21 +89,33 @@ class AutoNLP:
                 "hub_model": hub_model,
             },
         }
-        json_resp = http_post(path="/projects/create", payload=payload, token=self.token).json()
-        proj_name = json_resp["proj_name"]
+        json_resp = http_post(path="/projects/create", payload=payload, token=login_info["token"]).json()
+        proj_username, proj_name = json_resp["username"], json_resp["proj_name"]
         created = json_resp["created"]
         if created is True:
-            logger.info(f"✅ Successfully created project: '{proj_name}'!")
+            logger.info(f"✅ Successfully created project: '{proj_username}/{proj_name}'!")
         else:
-            logger.info(f"🤙 Project '{proj_name}' already exists, it was loaded successfully.")
-        self._project = Project.from_json_resp(json_resp, token=self.token)
+            logger.info(f"🤙 Project '{proj_username}{proj_name}' already exists, it was loaded successfully.")
+        self._project = Project.from_json_resp(json_resp, token=login_info["token"])
         self._project.refresh()
         return self._project
 
     def create_evaluation(
-        self, task: str, dataset: str, model: str, split: str, col_mapping: str = None, config: str = None
-    ):
-        self._login_from_conf()
+        self,
+        task: str,
+        dataset: str,
+        model: str,
+        split: str,
+        col_mapping: Optional[str] = None,
+        config: Optional[str] = None,
+        username: Optional[str] = None,
+    ) -> Evaluate:
+        login_info = login_from_conf(save_dir=self.config_dir)
+        if username is None:
+            username = login_info["selected_identity"]
+            logger.warning(f"Creating evaluation project under identity: '{username}'")
+        if username not in [identity.name for identity in login_info["identities"]]:
+            raise ForbiddenError(f"Cannot impersonate '{username}'")
 
         splits = get_dataset_splits(dataset=dataset, config=config)
         if split not in splits:
@@ -130,13 +137,12 @@ class AutoNLP:
 
         mapping_dict = {}
         if col_mapping:
-            col_mapping = col_mapping.strip().split(",")
-            for c_m in col_mapping:
+            for c_m in col_mapping.strip().split(","):
                 k, v = c_m.split(":")
                 mapping_dict[k] = v
 
         payload = {
-            "username": self.username,
+            "username": login_info["selected_identity"],
             "dataset": dataset,
             "task": task_id,
             "model": model,
@@ -144,15 +150,27 @@ class AutoNLP:
             "split": split,
             "config": config,
         }
-        json_resp = http_post(path="/evaluate/create", payload=payload, token=self.token).json()
-        self._eval_proj = Evaluate.from_json_resp(json_resp, token=self.token)
+        json_resp = http_post(path="/evaluate/create", payload=payload, token=login_info["token"]).json()
+        self._eval_proj = Evaluate.from_json_resp(json_resp, token=login_info["token"])
         return self._eval_proj
 
-    def create_benchmark(self, dataset: str, submission: str, eval_name: str):
-        self._login_from_conf()
+    def create_benchmark(
+        self,
+        dataset: str,
+        submission: str,
+        eval_name: str,
+        username: Optional[str] = None,
+    ):
+        login_info = login_from_conf(save_dir=self.config_dir)
+        if username is None:
+            username = login_info["selected_identity"]
+            logger.warning(f"Creating benhchmark project under identity: '{username}'")
+        if username not in [identity.name for identity in login_info["identities"]]:
+            raise ForbiddenError(f"Cannot impersonate '{username}'")
+
         task_id = 1
         payload = {
-            "username": self.username,
+            "username": username,
             "dataset": dataset,
             "task": task_id,
             "model": eval_name,
@@ -161,24 +179,27 @@ class AutoNLP:
             "split": "test",
             "config": None,
         }
-        json_resp = http_post(path="/evaluate/create", payload=payload, token=self.token).json()
-        self._eval_proj = Evaluate.from_json_resp(json_resp, token=self.token)
+        json_resp = http_post(path="/evaluate/create", payload=payload, token=login_info["token"]).json()
+        self._eval_proj = Evaluate.from_json_resp(json_resp, token=login_info["token"])
         return self._eval_proj
 
     def get_eval_job_status(self, eval_job_id: int) -> int:
-        self._login_from_conf()
-        json_resp = http_get(path=f"/evaluate/status/{eval_job_id}", token=self.token).json()
+        json_resp = http_get(path=f"/evaluate/status/{eval_job_id}", token=self.get_token()).json()
         return json_resp["status"]
 
-    def get_project(self, name: str, is_eval: bool = False):
+    def get_project(self, name: str, username: Optional[str] = None, is_eval: bool = False):
         """Retrieves a project"""
-        self._login_from_conf()
-        if self.username is None:
-            raise UnauthenticatedError("❌ Credentials not found ! Please login to AutoNLP first.")
+        login_info = login_from_conf(save_dir=self.config_dir)
+        if username is None:
+            username = login_info["selected_identity"]
+            logger.warning(f"Creating benhchmark project under identity: '{username}'")
+        if username not in [identity.name for identity in login_info["identities"]]:
+            raise ForbiddenError(f"Cannot impersonate '{username}'")
+
         if is_eval:
             logger.info(f"☁ Retrieving evaluation project '{name}' from AutoNLP...")
             try:
-                json_resp = http_get(path=f"/evaluate/status/{name}", token=self.token).json()
+                json_resp = http_get(path=f"/evaluate/status/{name}", token=login_info["token"]).json()
             except requests.exceptions.HTTPError as err:
                 if err.response.status_code == 404:
                     raise ValueError(
@@ -187,47 +208,55 @@ class AutoNLP:
                 raise
             return format_eval_status(json_resp)
 
-        if self._project is None or self._project.name != name:
+        if self._project is None or self._project.name != name or self._project.user != username:
             logger.info(f"☁ Retrieving project '{name}' from AutoNLP...")
             try:
-                json_resp = http_get(path=f"/projects/{self.username}/{name}", token=self.token).json()
+                json_resp = http_get(path=f"/projects/{username}/{name}", token=login_info["token"]).json()
             except requests.exceptions.HTTPError as err:
                 if err.response.status_code == 404:
                     raise ValueError(f"❌ Project '{name}' not found. Please create the project using create_project")
                 else:
                     raise
-            self._project = Project.from_json_resp(json_resp, token=self.token)
+            self._project = Project.from_json_resp(json_resp, token=login_info["token"])
             self._project.refresh()
         else:
             self._project.refresh()
         logger.info(f"✅ Successfully loaded project: '{name}'!")
         return self._project
 
-    def get_metrics(self, project):
-        self._login_from_conf()
-        if self.username is None:
-            raise UnauthenticatedError("❌ Credentials not found ! Please login to AutoNLP first.")
+    def get_metrics(self, project: str, username: Optional[str] = None):
+        login_info = login_from_conf(self.config_dir)
+        if username is None:
+            username = login_info["selected_identity"]
+            logger.warning(f"Creating benhchmark project under identity: '{username}'")
+        if username not in [identity.name for identity in login_info["identities"]]:
+            raise ForbiddenError(f"Cannot impersonate '{username}'")
+
         try:
-            json_resp = http_get(path=f"/projects/{self.username}/{project}", token=self.token).json()
+            json_resp = http_get(path=f"/projects/{username}/{project}", token=login_info["token"]).json()
         except requests.exceptions.HTTPError as err:
             if err.response.status_code == 404:
                 raise ValueError(f"❌ Project '{project}' not found!") from err
             raise
         _metrics = Metrics.from_json_resp(
-            json_resp=json_resp, token=self.token, project_name=project, username=self.username
+            json_resp=json_resp, token=login_info["token"], project_name=project, username=username
         )
         return _metrics.print()
 
-    def predict(self, project, model_id, input_text):
-        self._login_from_conf()
-        if self.username is None:
-            raise UnauthenticatedError("❌ Credentials not found ! Please login to AutoNLP first.")
+    def predict(self, project: str, model_id: int, input_text: str, username: Optional[str] = None):
+        login_info = login_from_conf(self.config_dir)
+        if username is None:
+            username = login_info["selected_identity"]
+            logger.warning(f"Creating benhchmark project under identity: '{username}'")
+        if username not in [identity.name for identity in login_info["identities"]]:
+            raise ForbiddenError(f"Cannot impersonate '{username}'")
+
         try:
             repo_name = f"autonlp-{project}-{model_id}"
-            api_url = f"https://api-inference.huggingface.co/models/{self.username}/{repo_name}"
+            api_url = f"https://api-inference.huggingface.co/models/{username}/{repo_name}"
             payload = {"inputs": input_text}
             payload = json.dumps(payload)
-            headers = {"Authorization": f"Bearer {self.token}"}
+            headers = {"Authorization": f"Bearer {login_info['token']}"}
             response = requests.request("POST", api_url, headers=headers, data=payload)
             return json.loads(response.content.decode("utf-8"))
         except requests.exceptions.HTTPError as err:
@@ -235,21 +264,22 @@ class AutoNLP:
                 raise ValueError("❌ Model not found.") from err
             raise
 
-    def list_projects(self, username: Optional[str] = None):
-        self._login_from_conf()
-        if self.username is None:
-            raise UnauthenticatedError("❌ Credentials not found ! Please login to AutoNLP first.")
-        # default to current user if username is not provided
+    def list_projects(self, username: Optional[str] = None) -> List[Project]:
+        login_info = login_from_conf()
         if username is None:
-            username = self.username
+            username = login_info["selected_identity"]
+        if username not in [identity.name for identity in login_info["identities"]]:
+            raise ForbiddenError(f"Cannot impersonate '{username}'")
 
         logger.info(f"📄 Retrieving projects of user {username}...")
-        json_resp = http_get(path=f"/projects/list?username={username}", token=self.token).json()
-        return [Project.from_json_resp(elt, token=self.token) for elt in json_resp]
+        json_resp = http_get(path=f"/projects/list?username={username}", token=login_info["token"]).json()
+        return [Project.from_json_resp(elt, token=login_info["token"]) for elt in json_resp]
 
-    def estimate(self, num_train_samples: int, proj_name: str) -> dict:
-        self._login_from_conf()
-        if self.username is None:
-            raise UnauthenticatedError("❌ Credentials not found ! Please login to AutoNLP first.")
+    def estimate(self, num_train_samples: int, proj_name: str, username: Optional[str] = None) -> dict:
+        login_info = login_from_conf()
+        if username is None:
+            username = login_info["selected_identity"]
+        if username not in [identity.name for identity in login_info["identities"]]:
+            raise ForbiddenError(f"Cannot impersonate '{username}'")
         project = self.get_project(name=proj_name)
         return project.estimate_cost(num_train_samples)

--- a/src/autonlp/cli/benchmark.py
+++ b/src/autonlp/cli/benchmark.py
@@ -6,7 +6,7 @@ from . import BaseAutoNLPCommand
 
 
 def create_benchmark_command_factory(args):
-    return CreateBenchmarkCommand(args.dataset, args.submission, args.eval_name)
+    return CreateBenchmarkCommand(args.dataset, args.submission, args.eval_name, args.username)
 
 
 class CreateBenchmarkCommand(BaseAutoNLPCommand):
@@ -34,13 +34,21 @@ class CreateBenchmarkCommand(BaseAutoNLPCommand):
             default=None,
             required=True,
         )
+        create_benchmark_parser.add_argument(
+            "--username",
+            metavar="USERNAME",
+            type=str,
+            default=None,
+            required=False,
+        )
 
         create_benchmark_parser.set_defaults(func=create_benchmark_command_factory)
 
-    def __init__(self, dataset, submission, eval_name):
+    def __init__(self, dataset, submission, eval_name, username):
         self._dataset = dataset
         self._submission = submission
         self._eval_name = eval_name
+        self._username = username
 
     def run(self):
         from ..autonlp import AutoNLP
@@ -48,8 +56,6 @@ class CreateBenchmarkCommand(BaseAutoNLPCommand):
         logger.info("Creating benchmark")
         client = AutoNLP()
         eval_project = client.create_benchmark(
-            dataset=self._dataset,
-            submission=self._submission,
-            eval_name=self._eval_name,
+            dataset=self._dataset, submission=self._submission, eval_name=self._eval_name, username=self._username
         )
         print(eval_project)

--- a/src/autonlp/cli/create_project.py
+++ b/src/autonlp/cli/create_project.py
@@ -16,7 +16,7 @@ def create_project_command_factory(args):
         raise ValueError("Please choose a value from 1 to 150 for max_models")
     if args.hub_model is None and args.language == "unk":
         raise ValueError("Please provide the `language` parameter")
-    return CreateProjectCommand(args.name, args.task, args.language, args.max_models, args.hub_model)
+    return CreateProjectCommand(args.name, args.task, args.language, args.max_models, args.hub_model, args.username)
 
 
 class CreateProjectCommand(BaseAutoNLPCommand):
@@ -58,14 +58,25 @@ class CreateProjectCommand(BaseAutoNLPCommand):
             metavar="HUB_MODEL",
             help="Provide model from hub that you want to finetune. E.g. abhishek/my_awesome_model. Note that if you provide a hub model, AutoNLP will ignore `language` parameter and disable model search.",
         )
+        create_project_parser.add_argument(
+            "--username",
+            type=str,
+            default=None,
+            required=False,
+            help="The user or organization name that will own the project. Defaults to the selected identiity.",
+        )
+
         create_project_parser.set_defaults(func=create_project_command_factory)
 
-    def __init__(self, name: str, task: str, language: str, max_models: int, hub_model: str = None):
+    def __init__(
+        self, name: str, task: str, language: str, max_models: int, hub_model: str = None, username: str = None
+    ):
         self._name = name
         self._task = task
         self._lang = language
         self._max_models = max_models
         self._hub_model = hub_model
+        self._username = username
 
     def run(self):
         from ..autonlp import AutoNLP
@@ -78,6 +89,10 @@ class CreateProjectCommand(BaseAutoNLPCommand):
             language=self._lang,
             max_models=self._max_models,
             hub_model=self._hub_model,
+            username=self._username,
         )
+
         print(project)
-        print(f'Upload files to your project: {RED}autonlp upload --project "{project.name}"{RST}')
+        print(
+            f'Upload files to your project: {RED}autonlp upload --project "{project.name}" --username "{project.user}"{RST}'
+        )

--- a/src/autonlp/cli/estimator.py
+++ b/src/autonlp/cli/estimator.py
@@ -1,5 +1,6 @@
 import sys
 from argparse import ArgumentParser
+from typing_extensions import Required
 
 from loguru import logger
 
@@ -7,7 +8,7 @@ from . import BaseAutoNLPCommand
 
 
 def estimator_command_factory(args):
-    return EstimatorCommand(args.num_train_samples, args.project_name)
+    return EstimatorCommand(args.num_train_samples, args.project_name, args.username)
 
 
 class EstimatorCommand(BaseAutoNLPCommand):
@@ -25,18 +26,28 @@ class EstimatorCommand(BaseAutoNLPCommand):
             required=True,
             help="The project's name",
         )
+        estimator_parser.add_argument(
+            "--username",
+            type=str,
+            required=False,
+            default=None,
+            help="The user or organization that owns the project. Defaults to the selcetd identity.",
+        )
         estimator_parser.set_defaults(func=estimator_command_factory)
 
-    def __init__(self, num_train_samples: int, proj_name: str):
+    def __init__(self, num_train_samples: int, proj_name: str, username: str = None):
         self._num_train_samples = num_train_samples
         self._proj_name = proj_name
+        self._username = username
 
     def run(self):
         from ..autonlp import AutoNLP
 
         client = AutoNLP()
         try:
-            resp = client.estimate(num_train_samples=self._num_train_samples, proj_name=self._proj_name)
+            resp = client.estimate(
+                num_train_samples=self._num_train_samples, proj_name=self._proj_name, username=self._username
+            )
             print(f"Cost range: {resp['cost_min']} - {resp['cost_max']} USD")
         except ValueError:
             logger.error("Something bad happened. Couldn't make the estimate.")

--- a/src/autonlp/cli/estimator.py
+++ b/src/autonlp/cli/estimator.py
@@ -1,6 +1,5 @@
 import sys
 from argparse import ArgumentParser
-from typing_extensions import Required
 
 from loguru import logger
 

--- a/src/autonlp/cli/evaluate.py
+++ b/src/autonlp/cli/evaluate.py
@@ -11,7 +11,9 @@ def create_evaluation_command_factory(args):
     if args.task not in DATASETS_TASKS:
         if args.col_mapping is None:
             raise Exception("`col_mapping` is required if task is not a datasets task")
-    return CreateEvaluationCommand(args.task, args.dataset, args.model, args.col_mapping, args.split, args.config)
+    return CreateEvaluationCommand(
+        args.task, args.dataset, args.model, args.col_mapping, args.split, args.config, args.username
+    )
 
 
 class CreateEvaluationCommand(BaseAutoNLPCommand):
@@ -64,16 +66,33 @@ class CreateEvaluationCommand(BaseAutoNLPCommand):
             required=False,
             help="Which config of dataset to use for evaluation. If not provided, this will default to None.",
         )
+        create_evaluation_parser.add_argument(
+            "--username",
+            type=str,
+            default=None,
+            required=False,
+            help="The user or organization that will own the evaluation project. Defaults to the selected identity.",
+        )
 
         create_evaluation_parser.set_defaults(func=create_evaluation_command_factory)
 
-    def __init__(self, task: str, dataset: str, model: str, col_mapping: str, split: str, config: str = None):
+    def __init__(
+        self,
+        task: str,
+        dataset: str,
+        model: str,
+        col_mapping: str,
+        split: str,
+        config: str = None,
+        username: str = None,
+    ):
         self._task = task
         self._model = model
         self._dataset = dataset
         self._col_mapping = col_mapping
         self._split = split
         self._config = config
+        self._username = username
 
     def run(self):
         from ..autonlp import AutoNLP
@@ -87,5 +106,6 @@ class CreateEvaluationCommand(BaseAutoNLPCommand):
             split=self._split,
             col_mapping=self._col_mapping,
             config=self._config,
+            username=self._username,
         )
         print(eval_project)

--- a/src/autonlp/cli/list_identities.py
+++ b/src/autonlp/cli/list_identities.py
@@ -1,0 +1,39 @@
+from argparse import ArgumentParser
+
+from loguru import logger
+from prettytable import PrettyTable
+
+from ..auth import login_from_conf
+from ..utils import GREEN_TAG as GREEN
+from ..utils import RESET_TAG as RST
+from . import BaseAutoNLPCommand
+
+
+def list_identities_command_factory(args):
+    return ListIdentitiesCommand()
+
+
+class ListIdentitiesCommand(BaseAutoNLPCommand):
+    @staticmethod
+    def register_subcommand(parser: ArgumentParser):
+        list_identities_parser = parser.add_parser(
+            "list_identities", description="🎭 Lists AutoNLP identities the current user can impersonate"
+        )
+        list_identities_parser.set_defaults(func=list_identities_command_factory)
+
+    def run(self):
+        logger.info("Fetching identities...")
+        login_info = login_from_conf()
+        table = PrettyTable(field_names=["Selected", "Name", "Full name", "Organization"])
+        table.add_rows(
+            [
+                [
+                    f"{GREEN}X{RST}" if identity.name == login_info["selected_identity"] else " ",
+                    identity.name,
+                    identity.full_name,
+                    identity.is_org,
+                ]
+                for identity in login_info["identities"]
+            ]
+        )
+        print(table)

--- a/src/autonlp/cli/list_identities.py
+++ b/src/autonlp/cli/list_identities.py
@@ -28,10 +28,10 @@ class ListIdentitiesCommand(BaseAutoNLPCommand):
         table.add_rows(
             [
                 [
-                    f"{GREEN}X{RST}" if identity.name == login_info["selected_identity"] else " ",
-                    identity.name,
-                    identity.full_name,
-                    identity.is_org,
+                    f"{GREEN}X{RST}" if identity["name"] == login_info["selected_identity"] else " ",
+                    identity["name"],
+                    identity["full_name"],
+                    identity["is_org"],
                 ]
                 for identity in login_info["identities"]
             ]

--- a/src/autonlp/cli/list_projects.py
+++ b/src/autonlp/cli/list_projects.py
@@ -23,7 +23,7 @@ class ListProjectsCommand(BaseAutoNLPCommand):
             type=str,
             default=None,
             required=False,
-            help="Username of the owner of the projects, defaults to you",
+            help="Username of the owner of the projects, defaults to the selected identity",
         )
         list_projects_parser.set_defaults(func=list_projects_command_factory)
 

--- a/src/autonlp/cli/metrics.py
+++ b/src/autonlp/cli/metrics.py
@@ -22,7 +22,6 @@ class MetricsCommand(BaseAutoNLPCommand):
             required=False,
             help="The user or org that owns the project, defaults to the selected identity",
         )
-        metrics_parser.add_arge
         metrics_parser.set_defaults(func=metrics_command_factory)
 
     def __init__(self, project: str, username: str = None):

--- a/src/autonlp/cli/metrics.py
+++ b/src/autonlp/cli/metrics.py
@@ -7,25 +7,34 @@ from . import BaseAutoNLPCommand
 
 
 def metrics_command_factory(args):
-    return MetricsCommand(args.project)
+    return MetricsCommand(args.project, args.username)
 
 
 class MetricsCommand(BaseAutoNLPCommand):
     @staticmethod
     def register_subcommand(parser: ArgumentParser):
         metrics_parser = parser.add_parser("metrics", description="📊 Fetches models' metrics for a project in AutoNLP")
-        metrics_parser.add_argument("--project", type=str, default=None, required=True, help="The project ID")
+        metrics_parser.add_argument("--project", type=str, default=None, required=True, help="The project name")
+        metrics_parser.add_argument(
+            "--username",
+            type=str,
+            default=None,
+            required=False,
+            help="The user or org that owns the project, defaults to the selected identity",
+        )
+        metrics_parser.add_arge
         metrics_parser.set_defaults(func=metrics_command_factory)
 
-    def __init__(self, project: str = None):
+    def __init__(self, project: str, username: str = None):
         self._project = project
+        self._username = username
 
     def run(self):
         from ..autonlp import AutoNLP
 
         client = AutoNLP()
         try:
-            _ = client.get_metrics(project=self._project)
+            _ = client.get_metrics(project=self._project, username=self._username)
         except ValueError:
             logger.error("Something bad happened. No metrics found for request")
             sys.exit(1)

--- a/src/autonlp/cli/predict.py
+++ b/src/autonlp/cli/predict.py
@@ -4,7 +4,7 @@ from . import BaseAutoNLPCommand
 
 
 def predict_command_factory(args):
-    return PredictCommand(args.model_id, args.sentence, args.project)
+    return PredictCommand(args.model_id, args.sentence, args.project, args.username)
 
 
 class PredictCommand(BaseAutoNLPCommand):
@@ -28,16 +28,27 @@ class PredictCommand(BaseAutoNLPCommand):
             required=True,
             help="The input sentence to make predictions on! Don't forget to quote it 😉",
         )
+        predict_parser.add_argument(
+            "--username",
+            type=str,
+            default=None,
+            required=False,
+            help="The user or org that owns the project, defaults to the selected identity",
+        )
+
         predict_parser.set_defaults(func=predict_command_factory)
 
-    def __init__(self, model_id: int, sentence: str, project: str):
+    def __init__(self, model_id: int, sentence: str, project: str, username: str = None):
         self._model_id = model_id
         self._sentence = sentence
         self._project_name = project
+        self._username = username
 
     def run(self):
         from ..autonlp import AutoNLP
 
         client = AutoNLP()
-        prediction = client.predict(project=self._project_name, model_id=self._model_id, input_text=self._sentence)
+        prediction = client.predict(
+            project=self._project_name, model_id=self._model_id, input_text=self._sentence, username=self._username
+        )
         print(prediction)

--- a/src/autonlp/cli/project_info.py
+++ b/src/autonlp/cli/project_info.py
@@ -7,7 +7,7 @@ from . import BaseAutoNLPCommand
 
 
 def project_info_command_factory(args):
-    return ProjectInfoCommand(args.name, args.is_eval)
+    return ProjectInfoCommand(args.name, args.is_eval, args.username)
 
 
 class ProjectInfoCommand(BaseAutoNLPCommand):
@@ -18,13 +18,21 @@ class ProjectInfoCommand(BaseAutoNLPCommand):
         )
         project_info_parser.add_argument("--name", type=str, default=None, required=True, help="The project's name")
         project_info_parser.add_argument(
+            "--username",
+            type=str,
+            default=None,
+            required=False,
+            help="The user or org that owns the project, defaults to the selected identity",
+        )
+        project_info_parser.add_argument(
             "--is_eval", action="store_true", help="Use `--is_eval` flag if this is an evaluation project"
         )
         project_info_parser.set_defaults(func=project_info_command_factory)
 
-    def __init__(self, name: str, is_eval: bool):
+    def __init__(self, name: str, is_eval: bool, username: str = None):
         self._name = name
         self._is_eval = is_eval
+        self._username = username
 
     def run(self):
         from ..autonlp import AutoNLP
@@ -32,8 +40,10 @@ class ProjectInfoCommand(BaseAutoNLPCommand):
         logger.info(f"Fetching info for project: {self._name}")
         client = AutoNLP()
         try:
-            project = client.get_project(name=self._name, is_eval=self._is_eval)
+            project = client.get_project(name=self._name, is_eval=self._is_eval, username=self._username)
         except ValueError:
-            logger.error(f"Project {self._name} not found! You can create it using the create_project command.")
+            logger.error(
+                f"Project {self._username}/{self._name} not found! You can create it using the create_project command."
+            )
             sys.exit(1)
         print(project)

--- a/src/autonlp/cli/select_identity.py
+++ b/src/autonlp/cli/select_identity.py
@@ -1,8 +1,6 @@
 from argparse import ArgumentParser
 
-from loguru import logger
-
-from ..auth import login_from_conf, select_identity
+from ..auth import select_identity
 from . import BaseAutoNLPCommand
 
 
@@ -19,7 +17,6 @@ class SelectidentityCommand(BaseAutoNLPCommand):
         select_identity_parser.add_argument(
             "identity",
             type=str,
-            required=True,
             help="The new default identity. Run autonlp list_identities to visualize your options.",
         )
         select_identity_parser.set_defaults(func=select_identity_command_factory)
@@ -27,14 +24,6 @@ class SelectidentityCommand(BaseAutoNLPCommand):
     def __init__(self, identity: str):
         self._identity = identity
 
-    def run(self, identity: str):
-        logger.info("Fetching identities...")
-        login_info = login_from_conf()
-        if self._identity not in [choice.name for choice in login_info["identities"]]:
-            print(f"🛑 Cannot impersonate '{self._identity}'.")
-            print("Available choices are:")
-            for choice in login_info["identities"]:
-                print(f"  > '{choice.name}'")
-
+    def run(self):
         select_identity(new_identity=self._identity)
         print(f"✅ Successfully selected '{self._identity}' as the default identity")

--- a/src/autonlp/cli/select_identity.py
+++ b/src/autonlp/cli/select_identity.py
@@ -1,0 +1,40 @@
+from argparse import ArgumentParser
+
+from loguru import logger
+
+from ..auth import login_from_conf, select_identity
+from . import BaseAutoNLPCommand
+
+
+def select_identity_command_factory(args):
+    return SelectidentityCommand(args.identity)
+
+
+class SelectidentityCommand(BaseAutoNLPCommand):
+    @staticmethod
+    def register_subcommand(parser: ArgumentParser):
+        select_identity_parser = parser.add_parser(
+            "select_identity", description="🎭 Sets the default identity for AutoNLP"
+        )
+        select_identity_parser.add_argument(
+            "identity",
+            type=str,
+            required=True,
+            help="The new default identity. Run autonlp list_identities to visualize your options.",
+        )
+        select_identity_parser.set_defaults(func=select_identity_command_factory)
+
+    def __init__(self, identity: str):
+        self._identity = identity
+
+    def run(self, identity: str):
+        logger.info("Fetching identities...")
+        login_info = login_from_conf()
+        if self._identity not in [choice.name for choice in login_info["identities"]]:
+            print(f"🛑 Cannot impersonate '{self._identity}'.")
+            print("Available choices are:")
+            for choice in login_info["identities"]:
+                print(f"  > '{choice.name}'")
+
+        select_identity(new_identity=self._identity)
+        print(f"✅ Successfully selected '{self._identity}' as the default identity")

--- a/src/autonlp/cli/train.py
+++ b/src/autonlp/cli/train.py
@@ -11,7 +11,7 @@ from . import BaseAutoNLPCommand
 
 
 def train_command_factory(args):
-    return TrainCommand(args.project)
+    return TrainCommand(args.project, args.username)
 
 
 class TrainCommand(BaseAutoNLPCommand):
@@ -19,10 +19,18 @@ class TrainCommand(BaseAutoNLPCommand):
     def register_subcommand(parser: ArgumentParser):
         train_parser = parser.add_parser("train", description="🚀 Start the training for your project!")
         train_parser.add_argument("--project", type=str, default=None, required=True, help="The project name")
+        train_parser.add_argument(
+            "--username",
+            type=str,
+            default=None,
+            required=False,
+            help="The user or org that owns the project, defaults to the selected identity",
+        )
         train_parser.set_defaults(func=train_command_factory)
 
-    def __init__(self, name: str):
+    def __init__(self, name: str, username: str = None):
         self._name = name
+        self._username = username
 
     def run(self):
         from ..autonlp import AutoNLP
@@ -31,14 +39,14 @@ class TrainCommand(BaseAutoNLPCommand):
 
         client = AutoNLP()
         try:
-            project = client.get_project(name=self._name)
+            project = client.get_project(name=self._name, username=self._username)
         except ValueError:
             logger.error(f"Project {self._name} not found! You can create it using the create_project command.")
             sys.exit(1)
         try:
             project.train()
             print(
-                f"🚀 Awesome!! Monitor you training progress here: {RED}autonlp project_info --name {project.name}{RST}"
+                f"🚀 Awesome!! Monitor you training progress here: {RED}autonlp project_info --name {project.name} --username {project.username}{RST}"
             )
         except TrainingCancelledError:
             print(

--- a/src/autonlp/utils.py
+++ b/src/autonlp/utils.py
@@ -16,10 +16,6 @@ PURPLE_TAG = FORMAT_TAG.format(code=95)
 CYAN_TAG = FORMAT_TAG.format(code=96)
 
 
-class UnauthenticatedError(Exception):
-    pass
-
-
 class UnreachableAPIError(Exception):
     pass
 


### PR DESCRIPTION
# What's new
- New package `autonlp.auth` that centralizes everything related to authentication
- Authentication config is now stored under `~/.autonlp/auth.json` instead of `~/.autonlp/autonlp.json` to avoid bugs when upgrading AutoNLP
- Refactor of the AutoNLP client to use this new package
- Two new CLI commands:
    - `autonlp list_identities`, showing the user's identity and orgs
    - `autonlp select_identity`, that allow the user to change the default identity in AutoNLP
- A new `--username` argument in all CLI / Python commands that support it
