### PR TITLE
Bump datasets version to match AutoNLP backend

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ INSTALL_REQUIRES = [
     "tqdm==4.49",
     "prettytable==2.0.0",
     "huggingface_hub==0.0.12",
-    "datasets==1.9.0",
+    "datasets==1.11.0",
 ]
 
 QUALITY_REQUIRE = [


### PR DESCRIPTION
This PR bumps the `datasets` version to match that in the AutoNLP backend. 

The reason for this is that in `evaluate` I am using `autonlp` to run evaluation cron jobs and this forces me to use `datasets` v1.9 which doesn't have the ability to download individual remote files from the Hub (needed for the `superb` development).